### PR TITLE
Editorial: improve readability, harmonize terms

### DIFF
--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -105,7 +105,7 @@ as per {{?I-D.kuehlewind-update-tag}}.
 
 # Voucher Artifact with JSON Web Signature
 
-{{RFC7515}} deines the following serializations for JWS:
+{{RFC7515}} defines the following serializations for JWS:
 
 1. "JWS Compact Serialization" in {{Section 7.1 of RFC7515}}
 2. "JWS JSON Serialization" in {{Section 7.2 of RFC7515}} 

--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -67,7 +67,7 @@ document that is signed using a Cryptographic Message Syntax (CMS) structure.
 This document introduces a variant of the voucher artifact in which CMS is
 replaced by the JSON Object Signing and Encryption (JOSE) mechanism described in {{RFC7515}} to support deployments in which JOSE is preferred over CMS.
 
-In addition to explaining how the format is created, media types are registered and examples are provided.
+In addition to explaining how the format is created, the "application/voucher-jws+json" media type is registered and examples are provided.
 
 --- middle
 

--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -63,24 +63,28 @@ informative:
 --- abstract
 
 {{RFC8366}} defines a digital artifact called voucher as a YANG-defined JSON
-document that has been signed using a Cryptographic Message Syntax (CMS) structure.
-This memo introduces a variant of the voucher structure in which CMS is
+document that is signed using a Cryptographic Message Syntax (CMS) structure.
+This document introduces a variant of the voucher artifact in which CMS is
 replaced by the JSON Object Signing and Encryption (JOSE) mechanism described in {{RFC7515}} to support deployments in which JOSE is preferred over CMS.
 
-In addition to explaining how the format is created, MIME types are registered and examples are provided.
+In addition to explaining how the format is created, media types are registered and examples are provided.
 
 --- middle
 
 # Introduction
 
-"A Voucher Artifact for Bootstrapping Protocols" {{RFC8366}} describes a voucher artifact used in "Bootstrapping Remote Secure Key Infrastructure" {{BRSKI}} and
+"A Voucher Artifact for Bootstrapping Protocols" {{RFC8366}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{BRSKI}} and
 "Secure Zero Touch Provisioning" {{SZTP}} to transfer ownership of a device from a manufacturer to a new owner (site domain).
-That document defines the base YANG module and the serialization to JSON {{RFC8259}} with a CMS signature according to {{RFC5652}}.
-The resulting Voucher artifact has the media type "application/voucher-cms+json".
+That document provides a serialization of the voucher to JSON {{RFC8259}} with a signature according to the Cryptographic Message Syntax (CMS) {{RFC5652}}.
+The resulting voucher artifact has the media type "application/voucher-cms+json".
 
-{{?I-D.ietf-anima-constrained-voucher}} provides a mapping of the YANG module to CBOR {{?RFC8949}} with a signature format of COSE {{RFC8812}}.
+{{?I-D.ietf-anima-constrained-voucher}} provides a serialization of the voucher to CBOR {{?RFC8949}}
+with the signature format of COSE {{RFC8812}}
+and the media type "application/voucher-cose+cbor".
 
-This document provides a mapping of the Voucher YANG module to JSON format with the signature in form of JSON Web Signature (JWS) {{RFC7515}}.
+This document provides a serialization of the voucher to JSON {{RFC8259}}
+with the signature in form of JSON Web Signature (JWS) {{RFC7515}}
+and the media type "application/voucher-jws+json".
 The encoding specified in this document is used by {{?I-D.ietf-anima-brski-prm}}
 and may be more handy for use cases requiring signed JSON objects.
 
@@ -101,105 +105,109 @@ as per {{?I-D.kuehlewind-update-tag}}.
 
 # Voucher Artifact with JSON Web Signature
 
-The voucher {{RFC8366}} JSON structure consists of a nested map, the outer part of which is:
+{{RFC7515}} deines the following serializations for JWS:
+
+1. "JWS Compact Serialization" in {{Section 7.1 of RFC7515}}
+2. "JWS JSON Serialization" in {{Section 7.2 of RFC7515}} 
+- "General JWS JSON Serialization Syntax" in {{Section 7.2.1 of RFC7515}}   
+- "Flattened JWS JSON Serialization Syntax" in {{Section 7.2.2 of RFC7515}}
+
+This document makes use of the "General JWS JSON Serialization Syntax" to support multiple signatures,
+as already supported by {{RFC8366}} for CMS-signed vouchers.
+
+The {{RFC8366}} voucher data structure consists of a nested map, the outer map of which is:
 
 ~~~~
-{ "ietf-voucher:voucher" : { some inner items }}
+    { "ietf-voucher:voucher" : { inner map }}
 ~~~~
 
-this is considered the JSON payload as described in {{RFC7515}} section 3.
-
-{{RFC7515}} section 3.2 provides "JWS JSON Serialization Overview", find more details in {{RFC7515}} section 7 "Serializations".  
-The following serializations are defined:  
-
-1. "JWS Compact Serialization", {{RFC7515}} section 7.1  
-2. "JWS JSON Serialization" in, {{RFC7515}} section 7.2  
-- "General JWS JSON Serialization Syntax", {{RFC7515}} section 7.2.1  
-- "Flattened JWS JSON Serialization Syntax", {{RFC7515}} section 7.2.2  
-
-This document makes use of the "General JWS JSON Serialization Syntax" to support multiple signatures, as already supported by {{RFC8366}} for vouchers in form of "voucher-cms+json".
+This outer map is considered the JWS Payload as described in {{Section 3 of RFC7515}}.
+A "JWS JSON Serialization Overview" is given in {{Section 3.2 of RFC7515}} and more details on the JWS serializations in {{Section 7 of RFC7515}}.
 
 ## Voucher Representation in General JWS JSON Serialization Syntax
 
-The following figures gives an overview of the Voucher representation in "General JWS JSON Serialization Syntax".
+The following figure gives an overview of the Voucher representation in "General JWS JSON Serialization Syntax":
 
 ~~~~
-{
-  "payload": "BASE64URL(ietf-voucher:voucher)",
-  "signatures": [
     {
-      "protected": "BASE64URL(UTF8(JWS Protected Header))",
-      "signature": "base64encodedvalue=="
+      "payload": "BASE64URL(ietf-voucher:voucher)",
+      "signatures": [
+        {
+          "protected": "BASE64URL(UTF8(JWS Protected Header))",
+          "signature": "base64encodedvalue=="
+        }
+      ]
     }
-  ]
-}
 ~~~~
 {: #VoucherGeneralJWSFigure title='Voucher Representation in General JWS JSON Serialization Syntax' artwork-align="left"}
 
 ## JWS Payload of Voucher in General JWS JSON Serialization
 
-The following figures gives the decoded voucher payload representation JSON syntax.
+The following figure depicts the decoded JWS Payload in JSON syntax:
 
 ~~~~
-    "ietf-voucher:voucher": {
-      "assertion": "logged",
-      "serial-number": "0123456789",
-      "nonce": "5742698422680472",
-      "created-on": "2022-07-08T03:01:24.618Z",
-      "pinned-domain-cert": "base64encodedvalue=="
+    {
+      "ietf-voucher:voucher": {
+        "assertion": "logged",
+        "serial-number": "0123456789",
+        "nonce": "5742698422680472",
+        "created-on": "2022-07-08T03:01:24.618Z",
+        "pinned-domain-cert": "base64encodedvalue=="
+      }
     }
 ~~~~
-{: #VoucherGeneralJWSVoucherPayloadFigure title='Voucher payload representation JSON Syntax' artwork-align="left"}
+{: #VoucherGeneralJWSVoucherPayloadFigure title='Decoded JWS Payload in JSON Syntax' artwork-align="left"}
 
 ## JWS Protected Header of Voucher in General JWS JSON Serialization
 
 The standard header parameters "typ" and "alg" as described in {{RFC7515}} are utilized in the protected header.
-The "alg" header MUST contain the algorithm type used to create the signature, such as "ES256".
-The "typ" header SHOULD contain the value "TODO: voucher-jws+json", if present. 
+The "alg" header MUST contain the algorithm type used to create the signature, e.g., "ES256".
+The "typ" header SHOULD contain the value "TODO: voucher-jws+json", if present.
 
-If PKIX {{RFC5280}} format certificates are used then the {{RFC7515}} section 4.1.6 "x5c"
-certificate chain SHOULD be used to contain the certificate and chain.
+If X.509 (PKIX) certificates {{RFC5280}} are used,
+then the "x5c" parameter defined in {{Section 4.1.6 of RFC7515}} SHOULD be used to contain the certificate and chain.
 Vouchers will often need all certificates in the chain,
-including what would be considered the trust anchor certificate 
+including what would be considered the trust anchor certificate, 
 because intermediate devices (such as the Registrar) may need to audit the artifact,
-or end systems may need to pin a trust anchor for future operations.  
+or end systems may need to pin a trust anchor for future operations.
 Note, a trust anchor SHOULD be provided differently to be trusted.
-This is consistent with {{BRSKI}} section 5.5.2.
+This is consistent with {{Section 5.5.2 of BRSKI}}.
 
-The following figure gives the decoded protected header representation in JSON syntax.
+The following figure gives the decoded JWS Protected Header in JSON syntax:
 
 ~~~~
     { 
       "alg": "ES256",
       "typ": "voucher-jws+json",
       "x5c": [
-        "base64encodedvalue=="
+        "base64encodedvalue1==",
+        "base64encodedvalue2=="
       ]
     }  
 ~~~~
-{: #VoucherGeneralJWSProtectedHeaderFigure title='Protected Header Representation in JSON Syntax' artwork-align="left"}
+{: #VoucherGeneralJWSProtectedHeaderFigure title='JWS Protected Header in JSON Syntax' artwork-align="left"}
 
 # Privacy Considerations
 
 The Voucher Request reveals the IDevID of the component (Pledge) that is in the process of bootstrapping.
 
-This request occurs via HTTP-over-TLS, however the Pledge to Registrar TLS connection the Pledge is provisinally accepting the Registrar server certificate, and it is subject to disclosure by a Dolev-Yao attacker (a "malicious messenger"){{onpath}}.
-This is explained in {{BRSKI}} section 10.2.
+This request occurs via HTTP-over-TLS, however, for the Pledge-to-Registrar TLS connection, the Pledge is provisinally accepting the Registrar server certificate.
+Hence it is subject to disclosure by a Dolev-Yao attacker (a "malicious messenger"){{onpath}}, as explained in {{Section 10.2 of BRSKI}}.
 
 The use of a JWS header brings no new privacy considerations.
 
 # Security Considerations
 
-The issues of how {{RFC8366}} vouchers are used in a {{BRSKI}} system is addressed in section 11 of the {{BRSKI}} specification.
-This document does not change any of those issues, it just changes the signature technology used for voucher request and response objects.
+The issues of how {{RFC8366}} vouchers are used in a {{BRSKI}} system is addressed in {{Section 11 of BRSKI}}.
+This document does not change any of those issues, it just changes the signature technology used for voucher request and response artifacts.
 
-{{SZTP}} section 9 deals with voucher use in Secure Zero Touch Provisioning, and this document also makes no changes to security.
+{{Section 9 of SZTP}} deals with voucher use in Secure Zero Touch Provisioning, for which this document also makes no changes to security.
 
 # IANA Considerations
 
 ## Media-Type Registry
 
-This section registers the 'application/voucher-jws+json' in the "Media Types" registry.
+This section registers the "application/voucher-jws+json" in the "Media Types" registry.
 
 ### application/voucher-jws+json
 


### PR DESCRIPTION
I made an editorial pass over the document with the following changes:

* harmonize information given in introduction (voucher serializations and media type)
* replace "MIME type" with "media type"
* align term to describe format with RFC 7515 terms
* fixed incomplete sentence(s)
* changed to section linking in references
* clarified format figures (inconsistent use of curly brackets made usage unclear to me -- took Section 9 examples as ground truth to include brackets)