### PR TITLE
Fix idnits and improve Section 3

### DIFF
--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -204,7 +204,7 @@ The generated JWS Signature is base64url-encoded to become the string value of t
 
 # Privacy Considerations
 
-The voucher request reveals the IDevID of the component (Pledge) that is in the process of bootstrapping.
+The Voucher Request reveals the IDevID of the component (Pledge) that is in the process of bootstrapping.
 
 This request occurs via HTTP-over-TLS, however, for the Pledge-to-Registrar TLS connection, the Pledge is provisionally accepting the Registrar server certificate.
 Hence it is subject to disclosure by a Dolev-Yao attacker (a "malicious messenger") {{?ONPATH}}, as explained in {{Section 10.2 of BRSKI}}.
@@ -213,7 +213,7 @@ The use of a JWS header brings no new privacy considerations.
 
 # Security Considerations
 
-The issues of how RFC8366 vouchers are used in a {{BRSKI}} system is addressed in {{Section 11 of BRSKI}}.
+The issues of how {{I-D.draft-ietf-anima-rfc8366bis}} vouchers are used in a {{BRSKI}} system is addressed in {{Section 11 of BRSKI}}.
 This document does not change any of those issues, it just changes the signature technology used for voucher request and response artifacts.
 
 {{Section 9 of SZTP}} deals with voucher use in Secure Zero Touch Provisioning, for which this document also makes no changes to security.

--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -1,7 +1,7 @@
 ---
 title: JWS signed Voucher Artifacts for Bootstrapping Protocols
 abbrev: JWS-voucher
-docname: draft-ietf-anima-jws-voucher-06
+docname: draft-ietf-anima-jws-voucher-07
 
 stand_alone: true
 
@@ -10,7 +10,7 @@ area: Internet
 wg: anima Working Group
 kw: Internet-Draft
 cat: std
-updates: RFC8366
+updates: 8366
 
 pi:    # can use array (if all yes) or hash here
   toc: yes
@@ -55,17 +55,15 @@ informative:
   RFC8949:
   RFC8792:
   RFC8812:
-  onpath:
+  ONPATH:
     target: "https://mailarchive.ietf.org/arch/msg/saag/m1r9uo4xYznOcf85Eyk0Rhut598/"
     title: "can an on-path attacker drop traffic?"
     org: IETF
 
 --- abstract
 
-{{RFC8366}} defines a digital artifact called voucher as a YANG-defined JSON
-document that is signed using a Cryptographic Message Syntax (CMS) structure.
-This document introduces a variant of the voucher artifact in which CMS is
-replaced by the JSON Object Signing and Encryption (JOSE) mechanism described in {{RFC7515}} to support deployments in which JOSE is preferred over CMS.
+RFC8366 defines a digital artifact called voucher as a YANG-defined JSON document that is signed using a Cryptographic Message Syntax (CMS) structure.
+This document introduces a variant of the voucher artifact in which CMS is replaced by the JSON Object Signing and Encryption (JOSE) mechanism described in RFC7515 to support deployments in which JOSE is preferred over CMS.
 
 In addition to explaining how the format is created, the "application/voucher-jws+json" media type is registered and examples are provided.
 
@@ -75,11 +73,11 @@ In addition to explaining how the format is created, the "application/voucher-jw
 
 "A Voucher Artifact for Bootstrapping Protocols" {{RFC8366}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{BRSKI}} and
 "Secure Zero Touch Provisioning" {{SZTP}} to transfer ownership of a device from a manufacturer to a new owner (site domain).
-That document provides a serialization of the voucher to JSON {{RFC8259}} with a signature according to the Cryptographic Message Syntax (CMS) {{RFC5652}}.
+That document provides a serialization of the voucher to JSON {{RFC8259}} with a signature according to the Cryptographic Message Syntax (CMS) {{?RFC5652}}.
 The resulting voucher artifact has the media type "application/voucher-cms+json".
 
 {{?I-D.ietf-anima-constrained-voucher}} provides a serialization of the voucher to CBOR {{?RFC8949}}
-with the signature format of COSE {{RFC8812}}
+with the signature format of COSE {{?RFC8812}}
 and the media type "application/voucher-cose+cbor".
 
 This document provides a serialization of the voucher to JSON {{RFC8259}}
@@ -95,13 +93,16 @@ There is no provision across the different voucher signature formats that a rece
 For example, {{BRSKI}} provides this context via the media type for the voucher artifact.
 This document utilizes the optional "typ" (Type) Header Parameter of JWS {{RFC7515}} to provide information about the signed object.
 
-This document should be considered an update to {{RFC8366}} in the category of "See Also"
-as per {{?I-D.kuehlewind-update-tag}}.
+This document should be considered an update to {{RFC8366}} in the category of "See Also" as per {{?I-D.kuehlewind-update-tag}}.
 TODO: double check with RFC8366bis
 
 # Terminology
 
 {::boilerplate bcp14}
+
+BASE64URL(OCTETS) denotes the base64url encoding of OCTETS, per {{Section 2 of RFC7515}}.
+
+UTF8(STRING) denotes the octets of the UTF-8 {{RFC3629}} representation of STRING, per {{Section 1 of RFC7515}}.
 
 # Voucher Artifact with JSON Web Signature
 
@@ -109,41 +110,43 @@ TODO: double check with RFC8366bis
 
 1. "JWS Compact Serialization" in {{Section 7.1 of RFC7515}}
 2. "JWS JSON Serialization" in {{Section 7.2 of RFC7515}}
-- "General JWS JSON Serialization Syntax" in {{Section 7.2.1 of RFC7515}}   
+- "General JWS JSON Serialization Syntax" in {{Section 7.2.1 of RFC7515}}
 - "Flattened JWS JSON Serialization Syntax" in {{Section 7.2.2 of RFC7515}}
 
-This document makes use of the "General JWS JSON Serialization Syntax" to support multiple signatures,
+This document makes use of the "General JWS JSON Serialization Syntax" of {{RFC7515}} to support multiple signatures,
 as already supported by {{RFC8366}} for CMS-signed vouchers.
-
-The {{RFC8366}} voucher data structure consists of a nested map, the outer map of which is:
-
-~~~~
-    { "ietf-voucher:voucher" : { inner map }}
-~~~~
-
-This outer map is considered the JWS Payload as described in {{Section 3 of RFC7515}}.
-A "JWS JSON Serialization Overview" is given in {{Section 3.2 of RFC7515}} and more details on the JWS serializations in {{Section 7 of RFC7515}}.
+JWS signed voucher artifacts MUST use the "General JWS JSON Serialization Syntax" defined in {{Section 7.2.1 of RFC7515}}.
 
 ## Voucher Representation in General JWS JSON Serialization Syntax
 
-The following figure gives an overview of the Voucher representation in "General JWS JSON Serialization Syntax":
+A "JWS JSON Serialization Overview" is given in {{Section 3.2 of RFC7515}} and more details on the JWS serializations in {{Section 7 of RFC7515}}.
+The following figure gives an overview of the JWS signed voucher artifacts:
 
 ~~~~
     {
-      "payload": "BASE64URL(ietf-voucher:voucher)",
+      "payload": BASE64URL(Voucher Data Structure),
       "signatures": [
         {
-          "protected": "BASE64URL(UTF8(JWS Protected Header))",
-          "signature": "base64encodedvalue=="
+          "protected": BASE64URL(UTF8(JWS Protected Header)),
+          "signature": BASE64URL(JWS Signature)
         }
       ]
     }
 ~~~~
 {: #VoucherGeneralJWSFigure title='Voucher Representation in General JWS JSON Serialization Syntax' artwork-align="left"}
 
-## JWS Payload of Voucher in General JWS JSON Serialization
+## Voucher Data Structure
 
-The following figure depicts the decoded JWS Payload in JSON syntax:
+The Voucher Data Structure defined by {{RFC8366}} consists of a nested map, the outer map of which is:
+
+~~~~
+    { "ietf-voucher:voucher": { Inner Map }}
+~~~~
+{: #VoucherGeneralJWSVoucherDataStructureFigure title='Voucher Data Structure in JSON Syntax' artwork-align="left"}
+
+This outer map is considered the JWS Payload, which is base64url-encoded to become the string value of the "payload" member as described in {{Section 3 of RFC7515}}.
+The Inner Map is defined through the YANG module "ietf-voucher" in {{RFC8366}}.
+The following figure provides an example of a nested Voucher Data Structure in JSON syntax:
 
 ~~~~
     {
@@ -156,16 +159,17 @@ The following figure depicts the decoded JWS Payload in JSON syntax:
       }
     }
 ~~~~
-{: #VoucherGeneralJWSVoucherPayloadFigure title='Decoded JWS Payload in JSON Syntax' artwork-align="left"}
+{: #VoucherGeneralJWSVoucherPayloadFigure title='Decoded JWS Payload Example' artwork-align="left"}
 
-## JWS Protected Header of Voucher in General JWS JSON Serialization
+## JWS Protected Header
 
-The standard header parameters "typ" and "alg" as described in {{RFC7515}} are utilized in the protected header.
-The "alg" header MUST contain the algorithm type used to create the signature, e.g., "ES256".
-The "typ" header SHOULD contain the value "TODO: voucher-jws+json", if present.
+The JWS Protected Header uses the standard header parameters "alg", "typ", and "x5c" as described in {{RFC7515}}.
+The octets of the UTF-8 representation of the JWS Protected Header in JSON syntax are base64url-encoded to become the string value of the "protected" member as described in {{Section 3 of RFC7515}}.
 
-If X.509 (PKIX) certificates {{RFC5280}} are used,
-then the "x5c" parameter defined in {{Section 4.1.6 of RFC7515}} SHOULD be used to contain the certificate and chain.
+The "alg" parameter MUST contain the algorithm type used to create the signature, e.g., "ES256" as defined in {{Section 4.1.1 of RFC7515}}.
+If present, the "typ" parameter SHOULD contain the value "TODO: voucher-jws+json" as defined in {{Section 4.1.9 of RFC7515}}.
+
+If X.509 (PKIX) certificates {{RFC5280}} are used, the "x5c" parameter SHOULD contain the base64-encoded DER certificate and chain as defined in {{Section 4.1.6 of RFC7515}} (not base64url-encoded).
 Vouchers will often need all certificates in the chain,
 including what would be considered the trust anchor certificate,
 because intermediate devices (such as the Registrar) may need to audit the artifact,
@@ -173,7 +177,7 @@ or end systems may need to pin a trust anchor for future operations.
 Note, a trust anchor SHOULD be provided differently to be trusted.
 This is consistent with {{Section 5.5.2 of BRSKI}}.
 
-The following figure gives the decoded JWS Protected Header in JSON syntax:
+The following figure gives an example of a JWS Protected Header in JSON syntax:
 
 ~~~~
     {
@@ -185,20 +189,25 @@ The following figure gives the decoded JWS Protected Header in JSON syntax:
       ]
     }  
 ~~~~
-{: #VoucherGeneralJWSProtectedHeaderFigure title='JWS Protected Header in JSON Syntax' artwork-align="left"}
+{: #VoucherGeneralJWSProtectedHeaderFigure title='Decoded JWS Protected Header Example' artwork-align="left"}
+
+## JWS Signature
+
+The JWS Signature is generated over the JWS Protected Header and the Voucher Data Structure (= JWS Payload) as desribed in {{Section 5.1 of RFC7515}}.
+The generated JWS Signature is base64url-encoded to become the string value of the "signature" member.
 
 # Privacy Considerations
 
-The Voucher Request reveals the IDevID of the component (Pledge) that is in the process of bootstrapping.
+The voucher request reveals the IDevID of the component (Pledge) that is in the process of bootstrapping.
 
 This request occurs via HTTP-over-TLS, however, for the Pledge-to-Registrar TLS connection, the Pledge is provisinally accepting the Registrar server certificate.
-Hence it is subject to disclosure by a Dolev-Yao attacker (a "malicious messenger"){{onpath}}, as explained in {{Section 10.2 of BRSKI}}.
+Hence it is subject to disclosure by a Dolev-Yao attacker (a "malicious messenger") {{?ONPATH}}, as explained in {{Section 10.2 of BRSKI}}.
 
 The use of a JWS header brings no new privacy considerations.
 
 # Security Considerations
 
-The issues of how {{RFC8366}} vouchers are used in a {{BRSKI}} system is addressed in {{Section 11 of BRSKI}}.
+The issues of how RFC8366 vouchers are used in a {{BRSKI}} system is addressed in {{Section 11 of BRSKI}}.
 This document does not change any of those issues, it just changes the signature technology used for voucher request and response artifacts.
 
 {{Section 9 of SZTP}} deals with voucher use in Secure Zero Touch Provisioning, for which this document also makes no changes to security.

--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -175,7 +175,7 @@ The octets of the UTF-8 representation of the JWS Protected Header are base64url
 The "alg" parameter MUST contain the algorithm type used to create the signature, e.g., "ES256" as defined in {{Section 4.1.1 of RFC7515}}.
 If present, the "typ" parameter SHOULD contain the value "TODO: voucher-jws+json" as defined in {{Section 4.1.9 of RFC7515}}.
 
-If X.509 (PKIX) certificates {{RFC5280}} are used, the "x5c" parameter SHOULD contain the base64-encoded (not base64url-encoded) DER certificate or certificate chain as defined in {{Section 4.1.6 of RFC7515}}.
+If X.509 (PKIX) certificates {{RFC5280}} are used, the "x5c" parameter SHOULD contain the base64-encoded (not base64url-encoded) DER certificate and chain as defined in {{Section 4.1.6 of RFC7515}}.
 Vouchers will often need all certificates in the chain,
 including what would be considered the trust anchor certificate,
 because intermediate devices (such as the Registrar) may need to audit the artifact,

--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -71,38 +71,49 @@ In addition to explaining how the format is created, the "application/voucher-jw
 
 # Introduction
 
-"A Voucher Artifact for Bootstrapping Protocols" {{RFC8366}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{BRSKI}} and
+"A Voucher Artifact for Bootstrapping Protocols" {{I-D.draft-ietf-anima-rfc8366bis}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{BRSKI}} and
 "Secure Zero Touch Provisioning" {{SZTP}} to transfer ownership of a device from a manufacturer to a new owner (site domain).
-That document provides a serialization of the voucher to JSON {{RFC8259}} with a signature according to the Cryptographic Message Syntax (CMS) {{?RFC5652}}.
+That document provides a serialization of the voucher data to JSON {{RFC8259}} with a signature according to the Cryptographic Message Syntax (CMS) {{?RFC5652}}.
 The resulting voucher artifact has the media type "application/voucher-cms+json".
 
 {{?I-D.ietf-anima-constrained-voucher}} provides a serialization of the voucher to CBOR {{?RFC8949}}
 with the signature format of COSE {{?RFC8812}}
 and the media type "application/voucher-cose+cbor".
 
-This document provides a serialization of the voucher to JSON {{RFC8259}}
+This document provides a serialization of the voucher data to JSON {{RFC8259}}
 with the signature in form of JSON Web Signature (JWS) {{RFC7515}}
 and the media type "application/voucher-jws+json".
 The encoding specified in this document is used by {{?I-D.ietf-anima-brski-prm}}
 and may be more handy for use cases requiring signed JSON objects.
 
-This document does not extend the YANG definition of {{RFC8366}}.
+This document does not extend the YANG definition of {{I-D.draft-ietf-anima-rfc8366bis}}.
 
 With the availability of different encoded vouchers, it is up to an industry specific application statement to indicate/decide which voucher signature format is to be used.
 There is no provision across the different voucher signature formats that a receiver could safely recognize which format it uses unless additional context is provided.
 For example, {{BRSKI}} provides this context via the media type for the voucher artifact.
 This document utilizes the optional "typ" (Type) Header Parameter of JWS {{RFC7515}} to provide information about the signed object.
 
-This document should be considered an update to {{RFC8366}} in the category of "See Also" as per {{?I-D.kuehlewind-update-tag}}.
+This document should be considered an update to {{I-D.draft-ietf-anima-rfc8366bis}} in the category of "See Also" as per {{?I-D.kuehlewind-update-tag}}.
 TODO: double check with RFC8366bis
 
 # Terminology
 
 {::boilerplate bcp14}
 
-BASE64URL(OCTETS) denotes the base64url encoding of OCTETS, per {{Section 2 of RFC7515}}.
+Voucher:
+: A signed statement from the MASA service {{I-D.draft-ietf-anima-rfc8366bis}}.
 
-UTF8(STRING) denotes the octets of the UTF-8 {{RFC3629}} representation of STRING, per {{Section 1 of RFC7515}}.
+JWS Voucher:
+: A JWS structure signing the JSON Voucher Data.
+
+JSON Voucher Data:
+: An unsigned JSON document that conforms with the data model described by the ietf-voucher YANG module.
+
+BASE64URL(OCTETS):
+: Denotes the base64url encoding of OCTETS, per {{Section 2 of RFC7515}}.
+
+UTF8(STRING):
+: Denotes the octets of the UTF-8 {{RFC3629}} representation of STRING, per {{Section 1 of RFC7515}}.
 
 # Voucher Artifact with JSON Web Signature
 
@@ -115,16 +126,16 @@ UTF8(STRING) denotes the octets of the UTF-8 {{RFC3629}} representation of STRIN
 
 This document makes use of the "General JWS JSON Serialization Syntax" of {{RFC7515}} to support multiple signatures,
 as already supported by {{RFC8366}} for CMS-signed vouchers.
-JWS signed voucher artifacts MUST use the "General JWS JSON Serialization Syntax" defined in {{Section 7.2.1 of RFC7515}}.
 
 ## Voucher Representation in General JWS JSON Serialization Syntax
 
+JWS Voucher artifacts MUST use the "General JWS JSON Serialization Syntax" defined in {{Section 7.2.1 of RFC7515}}.
 A "JWS JSON Serialization Overview" is given in {{Section 3.2 of RFC7515}} and more details on the JWS serializations in {{Section 7 of RFC7515}}.
-The following figure gives an overview of the JWS signed voucher artifacts:
+The following figure summarizes the serialization of JWS Voucher artifacts:
 
 ~~~~
     {
-      "payload": BASE64URL(Voucher Data Structure),
+      "payload": BASE64URL(UTF8(JSON Voucher Data)),
       "signatures": [
         {
           "protected": BASE64URL(UTF8(JWS Protected Header)),
@@ -135,18 +146,10 @@ The following figure gives an overview of the JWS signed voucher artifacts:
 ~~~~
 {: #VoucherGeneralJWSFigure title='Voucher Representation in General JWS JSON Serialization Syntax' artwork-align="left"}
 
-## Voucher Data Structure
+## JSON Voucher Data
 
-The Voucher Data Structure defined by {{RFC8366}} consists of a nested map, the outer map of which is:
-
-~~~~
-    { "ietf-voucher:voucher": { Inner Map }}
-~~~~
-{: #VoucherGeneralJWSVoucherDataStructureFigure title='Voucher Data Structure in JSON Syntax' artwork-align="left"}
-
-This outer map is considered the JWS Payload, which is base64url-encoded to become the string value of the "payload" member as described in {{Section 3 of RFC7515}}.
-The Inner Map is defined through the YANG module "ietf-voucher" in {{RFC8366}}.
-The following figure provides an example of a nested Voucher Data Structure in JSON syntax:
+The JSON Voucher Data is an unsigned JSON document {{RFC8259}} that conforms with the data model described by the ietf-voucher YANG module {{RFC7950}} defined in {{Section 5.3 of RFC8366bis}} and is encoded using the rules defined in {{RFC7951}}.
+The following figure provides an example of JSON Voucher Data:
 
 ~~~~
     {
@@ -159,17 +162,20 @@ The following figure provides an example of a nested Voucher Data Structure in J
       }
     }
 ~~~~
-{: #VoucherGeneralJWSVoucherPayloadFigure title='Decoded JWS Payload Example' artwork-align="left"}
+{: #VoucherGeneralJWSVoucherPayloadFigure title='Unsigned voucher data in JSON syntax' artwork-align="left"}
+
+The JSON Voucher Data MUST be UTF-8 encoded to become the octet-based JWS Payload defined in {{RFC7515}}.
+The JWS Payload is further base64url-encoded to become the string value of the "payload" member as described in {{Section 3.2 of RFC7515}}.
 
 ## JWS Protected Header
 
-The JWS Protected Header uses the standard header parameters "alg", "typ", and "x5c" as described in {{RFC7515}}.
-The octets of the UTF-8 representation of the JWS Protected Header in JSON syntax are base64url-encoded to become the string value of the "protected" member as described in {{Section 3 of RFC7515}}.
+The JWS Protected Header defined in {{RFC7515}} uses the standard header parameters "alg", "typ", and "x5c".
+The octets of the UTF-8 representation of the JWS Protected Header are base64url-encoded to become the string value of the "protected" member as described in {{Section 3.2 of RFC7515}}.
 
 The "alg" parameter MUST contain the algorithm type used to create the signature, e.g., "ES256" as defined in {{Section 4.1.1 of RFC7515}}.
 If present, the "typ" parameter SHOULD contain the value "TODO: voucher-jws+json" as defined in {{Section 4.1.9 of RFC7515}}.
 
-If X.509 (PKIX) certificates {{RFC5280}} are used, the "x5c" parameter SHOULD contain the base64-encoded DER certificate and chain as defined in {{Section 4.1.6 of RFC7515}} (not base64url-encoded).
+If X.509 (PKIX) certificates {{RFC5280}} are used, the "x5c" parameter SHOULD contain the base64-encoded (not base64url-encoded) DER certificate or certificate chain as defined in {{Section 4.1.6 of RFC7515}}.
 Vouchers will often need all certificates in the chain,
 including what would be considered the trust anchor certificate,
 because intermediate devices (such as the Registrar) may need to audit the artifact,
@@ -193,14 +199,14 @@ The following figure gives an example of a JWS Protected Header in JSON syntax:
 
 ## JWS Signature
 
-The JWS Signature is generated over the JWS Protected Header and the Voucher Data Structure (= JWS Payload) as desribed in {{Section 5.1 of RFC7515}}.
+The JWS Signature is generated over the JWS Protected Header and the JWS Payload (= UTF-8 encoded JSON Voucher Data) as described in {{Section 5.1 of RFC7515}}.
 The generated JWS Signature is base64url-encoded to become the string value of the "signature" member.
 
 # Privacy Considerations
 
 The voucher request reveals the IDevID of the component (Pledge) that is in the process of bootstrapping.
 
-This request occurs via HTTP-over-TLS, however, for the Pledge-to-Registrar TLS connection, the Pledge is provisinally accepting the Registrar server certificate.
+This request occurs via HTTP-over-TLS, however, for the Pledge-to-Registrar TLS connection, the Pledge is provisionally accepting the Registrar server certificate.
 Hence it is subject to disclosure by a Dolev-Yao attacker (a "malicious messenger") {{?ONPATH}}, as explained in {{Section 10.2 of BRSKI}}.
 
 The use of a JWS header brings no new privacy considerations.


### PR DESCRIPTION
This update was originally triggered by the the [idnits error about references  in the abstract and warning about updates](https://author-tools.ietf.org/api/idnits?url=https://www.ietf.org/archive/id/draft-ietf-anima-jws-voucher-06.txt&submissioncheck=True), which was found while working on the shepherd write-up.

Some distance to my last review let me see further room for improvement of Section 3, where the format for JWS signed voucher artifacts is defined using references to RFC7515 and JSON examples.

The shepherd write-up template also mentions formal language, which the draft is somewhat lacking. Hence, I saw the need to improve the definitions of the format.

Please check and provide feedback!
Please note that there might be issues in the Markdown to RFC pipeline, as I only edited the .mkd without build step.


