### PR TITLE
New shepherd write-up instructions

### DIFF
--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -44,18 +44,18 @@ contributor:
   email: steffen.fries@siemens.com
 
 normative:
-  BRSKI: RFC8995
-  SZTP: RFC8572
   I-D.draft-ietf-anima-rfc8366bis:
+  RFC5280:
   RFC7515:
+  RFC8259:
 
 informative:
+  BRSKI: RFC8995
+  SZTP: RFC8572
   RFC3629:
-  RFC5280:
   RFC5652:
   RFC7950:
   RFC7951:
-  RFC8259:
   RFC8366:
   RFC8792:
   RFC8812:
@@ -67,7 +67,7 @@ informative:
 
 --- abstract
 
-TODO: [I-D.draft-ietf-anima-rfc8366bis] defines a digital artifact called voucher as a YANG-defined JSON document that is signed using a Cryptographic Message Syntax (CMS) structure.
+[TODO: I-D.draft-ietf-anima-rfc8366bis] defines a digital artifact called voucher as a YANG-defined JSON document that is signed using a Cryptographic Message Syntax (CMS) structure.
 This document introduces a variant of the voucher artifact in which CMS is replaced by the JSON Object Signing and Encryption (JOSE) mechanism described in RFC7515 to support deployments in which JOSE is preferred over CMS.
 
 In addition to explaining how the format is created, the "application/voucher-jws+json" media type is registered and examples are provided.
@@ -76,8 +76,8 @@ In addition to explaining how the format is created, the "application/voucher-jw
 
 # Introduction
 
-"A Voucher Artifact for Bootstrapping Protocols" {{I-D.draft-ietf-anima-rfc8366bis}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{BRSKI}} and
-"Secure Zero Touch Provisioning" {{SZTP}} to transfer ownership of a device from a manufacturer to a new owner (customer or operational domain).
+"A Voucher Artifact for Bootstrapping Protocols" {{I-D.draft-ietf-anima-rfc8366bis}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{?BRSKI}} and
+"Secure Zero Touch Provisioning" {{?SZTP}} to transfer ownership of a device from a manufacturer to a new owner (customer or operational domain).
 That document provides a serialization of the voucher data to JSON {{RFC8259}} (JSON Voucher Data) with cryptographic signing according to the Cryptographic Message Syntax (CMS) {{?RFC5652}}.
 The resulting voucher artifact has the media type "application/voucher-cms+json".
 
@@ -96,7 +96,7 @@ For example, {{BRSKI}} provides this context via the media type for the voucher 
 This document utilizes the optional "typ" (Type) Header Parameter of JWS {{RFC7515}} to provide information about the signed object.
 
 This document should be considered an update to {{I-D.draft-ietf-anima-rfc8366bis}} in the category of "See Also" as per {{?I-D.kuehlewind-update-tag}}.
-TODO: [Fix "Updates:" header with I-D.draft-ietf-anima-rfc8366bis number.]
+[TODO: Fix "Updates:" header with I-D.draft-ietf-anima-rfc8366bis number.]
 It does not extend the YANG definition of {{I-D.draft-ietf-anima-rfc8366bis}}.
 
 # Terminology
@@ -183,8 +183,8 @@ The following figure provides an example of JSON Voucher Data:
 
 The JWS Protected Header defined in {{RFC7515}} uses the standard header parameters "alg", "typ", and "x5c".
 The "alg" parameter MUST contain the algorithm type used to create the signature, e.g., "ES256" as defined in {{Section 4.1.1 of RFC7515}}.
-If present, the "typ" parameter SHOULD contain the value TODO: [voucher-jws+json] as defined in {{Section 4.1.9 of RFC7515}}.
-If X.509 (PKIX) certificates {{RFC5280}} are used, the "x5c" parameter SHOULD contain the base64-encoded (not base64url-encoded) DER certificate and chain as defined in {{Section 4.1.6 of RFC7515}}.
+If present, the "typ" parameter SHOULD contain the value "[TODO: voucher-jws+json]" as defined in {{Section 4.1.9 of RFC7515}}.
+If X.509 (PKIX) certificates {{RFC5280}} are used, the "x5c" parameter SHOULD contain the base64-encoded (not base64url-encoded) X.509 v3 (DER) certificate and chain as defined in {{Section 4.1.6 of RFC7515}}.
 
 Implementation Note:
 base64-encoded values opposed to base64url-encoded values may contain slashes ('/').
@@ -204,7 +204,7 @@ The following figure gives an example of a JWS Protected Header:
 ~~~~
     {
       "alg": "ES256",
-      "typ": "TODO: [voucher-jws+json]",
+      "typ": "[TODO: voucher-jws+json]",
       "x5c": [
         "base64encodedvalue1==",
         "base64encodedvalue2=="

--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -1,7 +1,7 @@
 ---
 title: JWS signed Voucher Artifacts for Bootstrapping Protocols
 abbrev: JWS-voucher
-docname: draft-ietf-anima-jws-voucher-08
+docname: draft-ietf-anima-jws-voucher-09
 submissionType: IETF
 
 stand_alone: true

--- a/anima-jws-voucher.mkd
+++ b/anima-jws-voucher.mkd
@@ -44,13 +44,13 @@ contributor:
   email: steffen.fries@siemens.com
 
 normative:
+  BRSKI: RFC8995
   I-D.draft-ietf-anima-rfc8366bis:
   RFC5280:
   RFC7515:
   RFC8259:
 
 informative:
-  BRSKI: RFC8995
   SZTP: RFC8572
   RFC3629:
   RFC5652:
@@ -76,7 +76,7 @@ In addition to explaining how the format is created, the "application/voucher-jw
 
 # Introduction
 
-"A Voucher Artifact for Bootstrapping Protocols" {{I-D.draft-ietf-anima-rfc8366bis}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{?BRSKI}} and
+"A Voucher Artifact for Bootstrapping Protocols" {{I-D.draft-ietf-anima-rfc8366bis}} defines a YANG-based data structure used in "Bootstrapping Remote Secure Key Infrastructure" {{!BRSKI}} and
 "Secure Zero Touch Provisioning" {{?SZTP}} to transfer ownership of a device from a manufacturer to a new owner (customer or operational domain).
 That document provides a serialization of the voucher data to JSON {{RFC8259}} (JSON Voucher Data) with cryptographic signing according to the Cryptographic Message Syntax (CMS) {{?RFC5652}}.
 The resulting voucher artifact has the media type "application/voucher-cms+json".


### PR DESCRIPTION
When wanting to submit my shepherd write-up, I discovered a newer version of the template in the Datatracker form, which pointed to more useful material. More work, but better documents...

First change is to correctly apply https://www.ietf.org/about/groups/iesg/statements/normative-informative-references/

> Normative references specify documents that must be read to understand or implement the technology in the new RFC

> Even references that are relevant only for optional features must be classified as normative if they meet the above conditions for normative references. 

This made me classify RFC8995 and RFC8572 as informational, as one does not need to fully understand the BRSKI exchanges to implement this new signature format for the Voucher. SZTP I understand more as an alternative use case.

However, RFC5280 is necessary to implement the optional `x5c` (to fully understand which of the many certificate formats must be passed in there).
I also re-added RFC8259 as normative, as it contains this tricky stuff like the optional slash escaping of which implementers of JWS Voucher must be aware.